### PR TITLE
修改Requester.ReadRes方法

### DIFF
--- a/protocol/network.go
+++ b/protocol/network.go
@@ -158,7 +158,7 @@ func (r *Requester) RefreshProxy() {
 }
 
 func (r *Requester) ReadRes(method, url string, body io.Reader) ([]byte, error) {
-	req, err := http.NewRequest("POST", url, body)
+	req, err := http.NewRequest(method, url, body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
原来的Requester.ReadRes方法内在构造HTTP请求的时候是直接构造POST请求，而并未使用传入参数中的method参数。另外参照Requester.Post和Requester.Get方法，猜想应该是根据传入的method参数构造相应的HTTP请求。