### PR TITLE
delete unused code block

### DIFF
--- a/protocol/network.go
+++ b/protocol/network.go
@@ -59,11 +59,6 @@ func (kv *KeyValue) Marshal() string {
 	case int:
 		valuestr = strconv.Itoa(t)
 	}
-	s := url.QueryEscape(valuestr)
-	s = strings.Replace(s, "%2F", "%2f", -1)
-	s = strings.Replace(s, "%2B", "%2b", -1)
-	s = strings.Replace(s, "%3D", "%3d", -1)
-	s = strings.Replace(s, "%2D", "%2d", -1)
 	return fmt.Sprintf("%s=%s", kv.Key, url.QueryEscape(valuestr))
 }
 


### PR DESCRIPTION
变量s在方法KeyValue.Marshal里面声明初始化后并没有在返回的结果里面用到。另外根据RFC3986 2.1节的内容，百分号编码里的十六进制数大小写是等价的。